### PR TITLE
Feature request: Multi-framework build (.NET 3.5)

### DIFF
--- a/ColorMine.Test/ColorMine.Test.csproj
+++ b/ColorMine.Test/ColorMine.Test.csproj
@@ -43,6 +43,15 @@
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NuGet|AnyCPU'">
+    <OutputPath>bin\NuGet\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/ColorMine.Test/ColorSpaces/Comparisons/Cie1976ComparisonTest.cs
+++ b/ColorMine.Test/ColorSpaces/Comparisons/Cie1976ComparisonTest.cs
@@ -5,7 +5,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ColorMine.Test.ColorSpaces.Comparisons
 {
+#if NET35
+	public class Cie1976ComparisonTestNet35
+#else
     public class Cie1976ComparisonTest
+#endif
     {
         [TestClass]
         public class Compare

--- a/ColorMine.Test/ColorSpaces/Comparisons/Cie94ComparisonTest.cs
+++ b/ColorMine.Test/ColorSpaces/Comparisons/Cie94ComparisonTest.cs
@@ -5,7 +5,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ColorMine.Test.ColorSpaces.Comparisons
 {
+#if NET35
+	public class Cie94ComparisonTestNet35
+#else
     public class Cie94ComparisonTest
+#endif
     {
         public class ApplicationConstants
         {

--- a/ColorMine.Test/ColorSpaces/Comparisons/CieDe2000ComparisonTest.cs
+++ b/ColorMine.Test/ColorSpaces/Comparisons/CieDe2000ComparisonTest.cs
@@ -12,12 +12,12 @@ namespace ColorMine.Test.ColorSpaces.Comparisons
         [TestClass]
         public class Compare
         {
-            private IDictionary<Tuple<ILab, ILab>, double> TestData { get; set; }
+            private IDictionary<KeyValuePair<ILab, ILab>, double> TestData { get; set; }
 
             [TestInitialize]
             public void Initialize()
             {
-                TestData = new Dictionary<Tuple<ILab, ILab>, double>();
+                TestData = new Dictionary<KeyValuePair<ILab, ILab>, double>();
                 var reader =
                     new System.IO.StreamReader(AppDomain.CurrentDomain.BaseDirectory +
                                                @"/TestData/CieDe2000TestData.dat");
@@ -41,7 +41,7 @@ namespace ColorMine.Test.ColorSpaces.Comparisons
                             A = Double.Parse(parts[4]),
                             B = Double.Parse(parts[5])
                         };
-                    var input = new Tuple<ILab, ILab>(a, b);
+                    var input = new KeyValuePair<ILab, ILab>(a, b);
                     var expected = Double.Parse(parts[6]);
                     TestData[input] = expected;
                 }
@@ -59,7 +59,7 @@ namespace ColorMine.Test.ColorSpaces.Comparisons
             {
                 foreach (var test in TestData)
                 {
-                    ReturnsExpectedValueForKnownInput(test.Value, test.Key.Item1, test.Key.Item2);
+                    ReturnsExpectedValueForKnownInput(test.Value, test.Key.Key, test.Key.Value);
                 }
             }
         }

--- a/ColorMine.Test/ColorSpaces/Comparisons/CieDe2000ComparisonTest.cs
+++ b/ColorMine.Test/ColorSpaces/Comparisons/CieDe2000ComparisonTest.cs
@@ -7,7 +7,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ColorMine.Test.ColorSpaces.Comparisons
 {
+#if NET35
+    public class CieDe2000ComparisonTestNet35
+#else
     public class CieDe2000ComparisonTest
+#endif
     {
         [TestClass]
         public class Compare

--- a/ColorMine.Test/ColorSpaces/Comparisons/CmcComparisonTest.cs
+++ b/ColorMine.Test/ColorSpaces/Comparisons/CmcComparisonTest.cs
@@ -5,7 +5,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ColorMine.Test.ColorSpaces.Comparisons
 {
+#if NET35
+	public class CmcComparisonTestNet35
+#else
     public class CmcComparisonTest
+#endif
     {
         [TestClass]
         public class Compare

--- a/ColorMine.Test/ColorSpaces/ConversionTests.cs
+++ b/ColorMine.Test/ColorSpaces/ConversionTests.cs
@@ -14,8 +14,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ColorMine.Test.ColorSpaces
 {
 
-
+#if NET35
+	public class RgbTestNet35
+#else
 	public class RgbTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -384,8 +387,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class CmyTestNet35
+#else
 	public class CmyTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -484,8 +490,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class CmykTestNet35
+#else
 	public class CmykTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -574,8 +583,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class HslTestNet35
+#else
 	public class HslTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -664,8 +676,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class LabTestNet35
+#else
 	public class LabTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -754,8 +769,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class LchTestNet35
+#else
 	public class LchTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -844,8 +862,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class XyzTestNet35
+#else
 	public class XyzTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -934,8 +955,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class LuvTestNet35
+#else
 	public class LuvTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -1034,8 +1058,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class HsvTestNet35
+#else
 	public class HsvTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -1134,8 +1161,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class HsbTestNet35
+#else
 	public class HsbTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest
@@ -1234,8 +1264,11 @@ namespace ColorMine.Test.ColorSpaces
 
         }
 	}
-
+#if NET35
+	public class HunterLabTestNet35
+#else
 	public class HunterLabTest
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest

--- a/ColorMine.Test/ColorSpaces/ConversionTests.tt
+++ b/ColorMine.Test/ColorSpaces/ConversionTests.tt
@@ -20,7 +20,11 @@ namespace ColorMine.Test.ColorSpaces
 {
 
 <# foreach (XmlNode fromSpace in colors) { var fromName = fromSpace.Name; #>
+#if NET35
+	public class <#= fromName #>TestNet35
+#else
 	public class <#= fromName #>Test
+#endif
     {
 		[TestClass]
         public class To : ColorSpaceTest

--- a/ColorMine.net35.Test/ColorMine.net35.Test.csproj
+++ b/ColorMine.net35.Test/ColorMine.net35.Test.csproj
@@ -43,6 +43,15 @@
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NuGet|AnyCPU'">
+    <OutputPath>bin\NuGet\</OutputPath>
+    <DefineConstants>TRACE;NET35</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/ColorMine.net35.Test/ColorMine.net35.Test.csproj
+++ b/ColorMine.net35.Test/ColorMine.net35.Test.csproj
@@ -1,0 +1,151 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2CD5228F-8642-46AA-8D76-C430F80DD4B5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ColorMine.Test</RootNamespace>
+    <AssemblyName>ColorMine.Test</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>C:\Users\joe\AppData\Local\Temp\vs5011.tmp\Release\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="..\ColorMine.Test\ColorSpaces\ColorSpaceTest.cs">
+      <Link>ColorSpaces\ColorSpaceTest.cs</Link>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>ColorSpaceTest.tt</DependentUpon>
+    </Compile>
+    <Compile Include="..\ColorMine.Test\ColorSpaces\Comparisons\Cie1976ComparisonTest.cs">
+      <Link>ColorSpaces\Comparisons\Cie1976ComparisonTest.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine.Test\ColorSpaces\Comparisons\Cie94ComparisonTest.cs">
+      <Link>ColorSpaces\Comparisons\Cie94ComparisonTest.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine.Test\ColorSpaces\Comparisons\CieDe2000ComparisonTest.cs">
+      <Link>ColorSpaces\Comparisons\CieDe2000ComparisonTest.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine.Test\ColorSpaces\Comparisons\CmcComparisonTest.cs">
+      <Link>ColorSpaces\Comparisons\CmcComparisonTest.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine.Test\ColorSpaces\ConversionTests.cs">
+      <Link>ColorSpaces\ConversionTests.cs</Link>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>ConversionTests.tt</DependentUpon>
+    </Compile>
+    <Compile Include="..\ColorMine.Test\Utility\DoubleExtensionTest.cs">
+      <Link>Utility\DoubleExtensionTest.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine.Test\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ColorMine.net35\ColorMine.net35.csproj">
+      <Project>{2bb66877-594c-40c3-a0d8-e742a6f2600a}</Project>
+      <Name>ColorMine.net35</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\ColorMine.Test\ColorSpaces\ColorSpaceTest.tt">
+      <Link>ColorSpaces\ColorSpaceTest.tt</Link>
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ColorSpaceTest.cs</LastGenOutput>
+    </None>
+    <None Include="..\ColorMine.Test\ColorSpaces\ConversionTests.tt">
+      <Link>ColorSpaces\ConversionTests.tt</Link>
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ConversionTests.cs</LastGenOutput>
+    </None>
+    <None Include="..\ColorMine.Test\TestData\CieDe2000TestData.dat">
+      <Link>TestData\CieDe2000TestData.dat</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\ColorMine.Test\TestData\ConversionResults.xml">
+      <Link>TestData\ConversionResults.xml</Link>
+    </Content>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ColorMine.net35/ColorMine.net35.csproj
+++ b/ColorMine.net35/ColorMine.net35.csproj
@@ -37,6 +37,15 @@
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NuGet|AnyCPU'">
+    <OutputPath>bin\NuGet\</OutputPath>
+    <DefineConstants>TRACE;NET35</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />

--- a/ColorMine.net35/ColorMine.net35.csproj
+++ b/ColorMine.net35/ColorMine.net35.csproj
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2BB66877-594C-40C3-A0D8-E742A6F2600A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ColorMine</RootNamespace>
+    <AssemblyName>ColorMine</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\ColorMine\ColorSpaces\ColorSpace.cs">
+      <Link>ColorSpaces\ColorSpace.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\ColorSpaces.cs">
+      <Link>ColorSpaces\ColorSpaces.cs</Link>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>ColorSpaces.tt</DependentUpon>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\ColorSpaceWithProfile.cs">
+      <Link>ColorSpaces\ColorSpaceWithProfile.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Comparisons\Cie1976Comparison.cs">
+      <Link>ColorSpaces\Comparisons\Cie1976Comparison.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Comparisons\Cie94Comparison.cs">
+      <Link>ColorSpaces\Comparisons\Cie94Comparison.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Comparisons\CieDe2000Comparison.cs">
+      <Link>ColorSpaces\Comparisons\CieDe2000Comparison.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Comparisons\CmcComparison.cs">
+      <Link>ColorSpaces\Comparisons\CmcComparison.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Comparisons\IColorSpaceComparison.cs">
+      <Link>ColorSpaces\Comparisons\IColorSpaceComparison.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\CmyConverter.cs">
+      <Link>ColorSpaces\Conversions\CmyConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\CmykConverter.cs">
+      <Link>ColorSpaces\Conversions\CmykConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\CmykProfileConverter.cs">
+      <Link>ColorSpaces\Conversions\CmykProfileConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\HsbConverter.cs">
+      <Link>ColorSpaces\Conversions\HsbConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\HslConverter.cs">
+      <Link>ColorSpaces\Conversions\HslConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\HsvConverter.cs">
+      <Link>ColorSpaces\Conversions\HsvConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\HunterLabConverter.cs">
+      <Link>ColorSpaces\Conversions\HunterLabConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\LabConverter.cs">
+      <Link>ColorSpaces\Conversions\LabConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\LchConverter.cs">
+      <Link>ColorSpaces\Conversions\LchConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\LuvConverter.cs">
+      <Link>ColorSpaces\Conversions\LuvConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\RgbConverter.cs">
+      <Link>ColorSpaces\Conversions\RgbConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\Utility\DoubleExtension.cs">
+      <Link>ColorSpaces\Conversions\Utility\DoubleExtension.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\XyzConverter.cs">
+      <Link>ColorSpaces\Conversions\XyzConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\ColorSpaces\Conversions\YxyConverter.cs">
+      <Link>ColorSpaces\Conversions\YxyConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\ColorMine\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\ColorMine\ColorSpaces\ColorSpaces.xml">
+      <SubType>Designer</SubType>
+      <Link>ColorSpaces\ColorSpaces.xml</Link>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\ColorMine\ColorMine.nuspec">
+      <Link>ColorMine.nuspec</Link>
+    </None>
+    <None Include="..\ColorMine\ColorSpaces\ColorSpaces.tt">
+      <Link>ColorSpaces\ColorSpaces.tt</Link>
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ColorSpaces.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ColorMine.nuspec
+++ b/ColorMine.nuspec
@@ -45,6 +45,8 @@ Fixed CIE2000 calculations</releaseNotes>
         <tags>color delta-e rgb to lab</tags>
     </metadata>
     <files>
-        <file src="bin\Release\ColorMine.dll" target="lib\ColorMine.dll" />
+        <!-- Ideally, there would be a ColorMine.netXXX entry here for each framework build. -->
+        <file src="ColorMine\bin\Release\ColorMine.dll" target="lib\net40\ColorMine.dll" />
+        <file src="ColorMine.net35\bin\Release\ColorMine.dll" target="lib\net35\ColorMine.dll" />
     </files>
 </package>

--- a/ColorMine.sln
+++ b/ColorMine.sln
@@ -1,9 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30110.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorMine", "ColorMine\ColorMine.csproj", "{AE7DC769-4A71-49BA-BDD7-281F3E70B02A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorMine.Test", "ColorMine.Test\ColorMine.Test.csproj", "{318DFB24-B947-4B07-AFDB-561A262EB424}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorMine.net35", "ColorMine.net35\ColorMine.net35.csproj", "{2BB66877-594C-40C3-A0D8-E742A6F2600A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{AE7DC769-4A71-49BA-BDD7-281F3E70B02A} = {AE7DC769-4A71-49BA-BDD7-281F3E70B02A}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorMine.net35.Test", "ColorMine.net35.Test\ColorMine.net35.Test.csproj", "{2CD5228F-8642-46AA-8D76-C430F80DD4B5}"
+	ProjectSection(ProjectDependencies) = postProject
+		{318DFB24-B947-4B07-AFDB-561A262EB424} = {318DFB24-B947-4B07-AFDB-561A262EB424}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,6 +31,14 @@ Global
 		{318DFB24-B947-4B07-AFDB-561A262EB424}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{318DFB24-B947-4B07-AFDB-561A262EB424}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{318DFB24-B947-4B07-AFDB-561A262EB424}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ColorMine.sln
+++ b/ColorMine.sln
@@ -20,23 +20,32 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		NuGet|Any CPU = NuGet|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AE7DC769-4A71-49BA-BDD7-281F3E70B02A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AE7DC769-4A71-49BA-BDD7-281F3E70B02A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE7DC769-4A71-49BA-BDD7-281F3E70B02A}.NuGet|Any CPU.ActiveCfg = Release|Any CPU
+		{AE7DC769-4A71-49BA-BDD7-281F3E70B02A}.NuGet|Any CPU.Build.0 = Release|Any CPU
 		{AE7DC769-4A71-49BA-BDD7-281F3E70B02A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AE7DC769-4A71-49BA-BDD7-281F3E70B02A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{318DFB24-B947-4B07-AFDB-561A262EB424}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{318DFB24-B947-4B07-AFDB-561A262EB424}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{318DFB24-B947-4B07-AFDB-561A262EB424}.NuGet|Any CPU.ActiveCfg = Release|Any CPU
+		{318DFB24-B947-4B07-AFDB-561A262EB424}.NuGet|Any CPU.Build.0 = Release|Any CPU
 		{318DFB24-B947-4B07-AFDB-561A262EB424}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{318DFB24-B947-4B07-AFDB-561A262EB424}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.NuGet|Any CPU.ActiveCfg = Release|Any CPU
+		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.NuGet|Any CPU.Build.0 = Release|Any CPU
 		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2BB66877-594C-40C3-A0D8-E742A6F2600A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.NuGet|Any CPU.ActiveCfg = Release|Any CPU
+		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.NuGet|Any CPU.Build.0 = Release|Any CPU
 		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CD5228F-8642-46AA-8D76-C430F80DD4B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/ColorMine/ColorSpaces/ColorSpaces.cs
+++ b/ColorMine/ColorSpaces/ColorSpaces.cs
@@ -1,38 +1,20 @@
-﻿
-
-
-
-
-
-
-
-
-//Note: This is a generated file.
+﻿//Note: This is a generated file.
 using ColorMine.ColorSpaces.Conversions;
 
 namespace ColorMine.ColorSpaces
 {
-
 	public interface IRgb : IColorSpace
     {
-
 		double R { get; set; }
-
 		double G { get; set; }
-
 		double B { get; set; }
-
     }
 
     public class Rgb : ColorSpace, IRgb
     {
-
 		public double R { get; set; }
-
 		public double G { get; set; }
-
 		public double B { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -45,27 +27,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface IXyz : IColorSpace
     {
-
 		double X { get; set; }
-
 		double Y { get; set; }
-
 		double Z { get; set; }
-
     }
 
     public class Xyz : ColorSpace, IXyz
     {
-
 		public double X { get; set; }
-
 		public double Y { get; set; }
-
 		public double Z { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -78,27 +51,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface IHsl : IColorSpace
     {
-
 		double H { get; set; }
-
 		double S { get; set; }
-
 		double L { get; set; }
-
     }
 
     public class Hsl : ColorSpace, IHsl
     {
-
 		public double H { get; set; }
-
 		public double S { get; set; }
-
 		public double L { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -111,27 +75,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface ILab : IColorSpace
     {
-
 		double L { get; set; }
-
 		double A { get; set; }
-
 		double B { get; set; }
-
     }
 
     public class Lab : ColorSpace, ILab
     {
-
 		public double L { get; set; }
-
 		public double A { get; set; }
-
 		public double B { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -144,27 +99,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface ILch : IColorSpace
     {
-
 		double L { get; set; }
-
 		double C { get; set; }
-
 		double H { get; set; }
-
     }
 
     public class Lch : ColorSpace, ILch
     {
-
 		public double L { get; set; }
-
 		public double C { get; set; }
-
 		public double H { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -177,27 +123,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface ILuv : IColorSpace
     {
-
 		double L { get; set; }
-
 		double U { get; set; }
-
 		double V { get; set; }
-
     }
 
     public class Luv : ColorSpace, ILuv
     {
-
 		public double L { get; set; }
-
 		public double U { get; set; }
-
 		public double V { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -210,27 +147,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface IYxy : IColorSpace
     {
-
 		double Y1 { get; set; }
-
 		double X { get; set; }
-
 		double Y2 { get; set; }
-
     }
 
     public class Yxy : ColorSpace, IYxy
     {
-
 		public double Y1 { get; set; }
-
 		public double X { get; set; }
-
 		public double Y2 { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -243,27 +171,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface ICmy : IColorSpace
     {
-
 		double C { get; set; }
-
 		double M { get; set; }
-
 		double Y { get; set; }
-
     }
 
     public class Cmy : ColorSpace, ICmy
     {
-
 		public double C { get; set; }
-
 		public double M { get; set; }
-
 		public double Y { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -276,31 +195,20 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface ICmyk : IColorSpace
     {
-
 		double C { get; set; }
-
 		double M { get; set; }
-
 		double Y { get; set; }
-
 		double K { get; set; }
-
     }
 
     public class Cmyk : ColorSpace, ICmyk
     {
-
 		public double C { get; set; }
-
 		public double M { get; set; }
-
 		public double Y { get; set; }
-
 		public double K { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -313,27 +221,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface IHsv : IColorSpace
     {
-
 		double H { get; set; }
-
 		double S { get; set; }
-
 		double V { get; set; }
-
     }
 
     public class Hsv : ColorSpace, IHsv
     {
-
 		public double H { get; set; }
-
 		public double S { get; set; }
-
 		public double V { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -346,27 +245,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface IHsb : IColorSpace
     {
-
 		double H { get; set; }
-
 		double S { get; set; }
-
 		double B { get; set; }
-
     }
 
     public class Hsb : ColorSpace, IHsb
     {
-
 		public double H { get; set; }
-
 		public double S { get; set; }
-
 		public double B { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -379,27 +269,18 @@ namespace ColorMine.ColorSpaces
         }
     }
 
-
 	public interface IHunterLab : IColorSpace
     {
-
 		double L { get; set; }
-
 		double A { get; set; }
-
 		double B { get; set; }
-
     }
 
     public class HunterLab : ColorSpace, IHunterLab
     {
-
 		public double L { get; set; }
-
 		public double A { get; set; }
-
 		public double B { get; set; }
-
 
         public override void Initialize(IRgb color)
         {
@@ -411,6 +292,5 @@ namespace ColorMine.ColorSpaces
             return HunterLabConverter.ToColor(this);
         }
     }
-
 
 }

--- a/ColorMine/colormine.csproj
+++ b/ColorMine/colormine.csproj
@@ -42,12 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/ColorMine/colormine.csproj
+++ b/ColorMine/colormine.csproj
@@ -37,6 +37,15 @@
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NuGet|AnyCPU'">
+    <OutputPath>bin\NuGet\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
@@ -92,6 +101,9 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>nuget pack "$(SolutionDir)ColorMine.nuspec" -OutputDirectory "$(SolutionDir)\"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
These changes satisfy the use cases below for .NET 3.5:
-   Use case 1: I am a ColorMine developer, and I want to, at the click of a button, build assemblies for multiple .NET framework versions from non-duplicated source files.
-   Use case 2: I am a ColorMine developer, and I want to, at the click of a button, build a ColorMine NuGet package that includes all .NET framework builds in my solution.
-   Use case 3: I am a ColorMine developer, and I want to, at the click of a button, build unit tests for multiple .NET framework versions from non-duplicated source files.
-   Use case 4: I am a ColorMine developer, and I want to, at the click of a button, run all unit tests for all included .NET framework builds in my solution.

I will add multi-framework build support for 4.0, 4.5, and 4.5.1 if you accept this pull request.

Please let me know if you have any questions.
